### PR TITLE
bugfix: 在锤子手机上获取局域网ip错误

### DIFF
--- a/app/src/main/java/com/xanarry/lantrans/utils/Utils.java
+++ b/app/src/main/java/com/xanarry/lantrans/utils/Utils.java
@@ -51,10 +51,14 @@ public class Utils {
             while (allNetInterfaces.hasMoreElements()) {
                 NetworkInterface netInterface = (NetworkInterface) allNetInterfaces.nextElement();
                 //System.out.println(netInterface.getName());
+                if (netInterface.isLoopback() || netInterface.isPointToPoint()) {
+                    continue;
+                }
+
                 Enumeration<?> addresses = netInterface.getInetAddresses();
                 while (addresses.hasMoreElements()) {
                     InetAddress tempIP = (InetAddress) addresses.nextElement();
-                    if (tempIP != null && tempIP instanceof Inet4Address && !tempIP.getHostAddress().equals("127.0.0.1")) {
+                    if (tempIP != null && tempIP instanceof Inet4Address) {
                         //System.out.println("本机的IP=" + tempIP.getHostAddress());
                         IP = tempIP;
                     }


### PR DESCRIPTION
锤子手机上有个 v4-rmnet_data6 网络接口，可以动过判断是不是点对点来排除掉,另外可以直接过滤掉loop的网络接口